### PR TITLE
Fix casting warning

### DIFF
--- a/Classes/ELCImagePicker/ELCConsole.m
+++ b/Classes/ELCImagePicker/ELCConsole.m
@@ -66,7 +66,7 @@ static ELCConsole *_mainconsole;
 
 - (int)numOfSelectedElements {
     
-    return [myIndex count];
+    return (int)[myIndex count];
 }
 
 @end


### PR DESCRIPTION
Array count returns a unsigned long, but the numOfSelectedElements returns an int. Cast to an int to mask warning. This will work as long as the array does not have more than  2,147,483,647 elements in it.